### PR TITLE
Switch to new tft_espi library 

### DIFF
--- a/TTGO_Hello_world/platformio.ini
+++ b/TTGO_Hello_world/platformio.ini
@@ -44,5 +44,5 @@ build_flags =
   -DSPI_READ_FREQUENCY=6000000
 
 lib_deps =
-    TFT_eSPI@1.4.21    
+    bodmer/TFT_eSPI@^2.3.67   
     Button2@1.0.0

--- a/TTGO_example/platformio.ini
+++ b/TTGO_example/platformio.ini
@@ -44,5 +44,5 @@ build_flags =
   -DSPI_READ_FREQUENCY=6000000
 
 lib_deps =
-    TFT_eSPI@1.4.21    
+    bodmer/TFT_eSPI@^2.3.67   
     Button2@1.0.0


### PR DESCRIPTION
The old  tft_espi library no longer worked in platformio. this one seems to be the continuation and works as a drop in replacement.
Both sketches were tested.

Closes: https://github.com/JakubAndrysek/TTGO_T_Display/issues/3